### PR TITLE
Fixing missing WhammyRecorder

### DIFF
--- a/MediaStreamRecorder-standalone.js
+++ b/MediaStreamRecorder-standalone.js
@@ -560,6 +560,39 @@ function WhammyRecorderHelper(mediaStream, root) {
     var self = this;
 }
 
+// =================
+// WhammyRecorder.js
+
+function WhammyRecorder(mediaStream) {
+    // void start(optional long timeSlice)
+    // timestamp to fire "ondataavailable"
+    this.start = function(timeSlice) {
+        timeSlice = timeSlice || 1000;
+
+        mediaRecorder = new WhammyRecorderHelper(mediaStream, this);
+
+        mediaRecorder.record();
+
+        timeout = setInterval(function() {
+            mediaRecorder.requestData();
+        }, timeSlice);
+    };
+
+    this.stop = function() {
+        if (mediaRecorder) {
+            mediaRecorder.stop();
+            clearTimeout(timeout);
+        }
+    };
+
+    this.ondataavailable = function() {
+    };
+
+    // Reference to "WhammyRecorder" object
+    var mediaRecorder;
+    var timeout;
+}
+
 // Muaz Khan     - https://github.com/muaz-khan 
 // neizerth      - https://github.com/neizerth
 // MIT License   - https://www.webrtc-experiment.com/licence/


### PR DESCRIPTION
The standalone version did not work with Chrome since WhammyRecorder was missing.
