### PR TITLE
Fixed MediaStreamRecorder audio bug

### DIFF
--- a/MediaStreamRecorder-standalone.js
+++ b/MediaStreamRecorder-standalone.js
@@ -23,7 +23,7 @@ function MediaStreamRecorder(mediaStream) {
         // video recorder (in GIF format)
         if (this.mimeType === 'image/gif') Recorder = window.GifRecorder;
 
-        mediaRecorder = new Recorder(mediaStream);
+        mediaRecorder = new Recorder(mediaStream, config.type);
         mediaRecorder.ondataavailable = this.ondataavailable;
         mediaRecorder.onstop = this.onstop;
 
@@ -140,11 +140,11 @@ var ObjectStore = {
 * Also extract the encoded data and create blobs on every timeslice passed from start function or RequestData function called by UA.
 */
 
-function MediaRecorderWrapper(mediaStream) {
+function MediaRecorderWrapper(mediaStream, type) {
     // if user chosen only audio option; and he tried to pass MediaStream with
     // both audio and video tracks;
     // using a dirty workaround to generate audio-only stream so that we can get audio/ogg output.
-    if (this.type == 'audio' && mediaStream.getVideoTracks && mediaStream.getVideoTracks().length && !navigator.mozGetUserMedia) {
+    if (type === 'audio' && mediaStream.getVideoTracks && mediaStream.getVideoTracks().length && !navigator.mozGetUserMedia) {
         var context = new AudioContext();
         var mediaStreamSource = context.createMediaStreamSource(mediaStream);
 


### PR DESCRIPTION
In MediaStreamRecorder there is a (not so) dirty hack to record audio when the stream contains both video and audio (otherwise video/webm blobs are recorded).
The hack uses this.type which is not yet set (the propertiesMerge is only done after construction).
As a workaround I passed config.type to Recorder constructor since in MediaStreamRecorder the type can be used right away to change the mediastream.
