### PR TITLE
Fixed #50 (Failed to construct 'AudioContext')

### DIFF
--- a/MediaStreamRecorder.js
+++ b/MediaStreamRecorder.js
@@ -218,6 +218,9 @@ function MultiStreamRecorder(arrayOfMediaStreams) {
         mediaRecorder.stop(function(blob) {
             callback(blob);
         });
+				
+		// via: @suhaibjanjua -> issue #50
+        self.audioContext.close();
     };
 
     function getMixedAudioStream() {

--- a/README.md
+++ b/README.md
@@ -519,6 +519,7 @@ videoRecorder.speed = 100;
 1. [Muaz Khan](https://github.com/muaz-khan)
 2. [neizerth](https://github.com/neizerth)
 3. [andersaloof](https://github.com/andersaloof)
+4. [Suhaib Janjua](https://github.com/suhaibjanjua)
 
 ## License
 


### PR DESCRIPTION
AudioContext was not closing when recording is stopped. That's why after few attempts the hardware reaches to the maximum contexts bound limit which is (6). This commit fixed the #50 issue by closing the existing context so that no matter how much times you start/stop recording; it never produces.