### PR TITLE
deprecated recorder api

### DIFF
--- a/MediaStreamRecorder.js
+++ b/MediaStreamRecorder.js
@@ -1803,7 +1803,7 @@ function WhammyRecorderHelper(mediaStream, root) {
             try{
                 video.srcObject = mediaStream
             }catch(err){
-				video.src = URL.createObjectURL(mediaStream);
+                video.src = URL.createObjectURL(mediaStream);
             }
 
             video.width = this.video.width;

--- a/MediaStreamRecorder.js
+++ b/MediaStreamRecorder.js
@@ -1800,7 +1800,11 @@ function WhammyRecorderHelper(mediaStream, root) {
             video = this.video.cloneNode();
         } else {
             video = document.createElement('video');
-            video.src = URL.createObjectURL(mediaStream);
+            try{
+                video.srcObject = mediaStream
+            }catch(err){
+				video.src = URL.createObjectURL(mediaStream);
+            }
 
             video.width = this.video.width;
             video.height = this.video.height;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL

The use of a MediaStream object as an input to this method is in the process of being deprecated.

Btw Safari 11 is now support MediaStream API